### PR TITLE
Update builder specification for v0.11.0

### DIFF
--- a/builder.md
+++ b/builder.md
@@ -20,7 +20,8 @@ on the placeholders the template files hold. For example: the [solarized
 scheme](https://github.com/base16-project/base16-schemes/blob/main/solarized-dark.yaml)
 
 A base16 builder is, essentially, an application that somehow implements the
-_building_ feature specification.
+_building_ feature specification: filling the placeholders on templates with
+scheme colors.
 
 Builders are categorized into:
 

--- a/builder.md
+++ b/builder.md
@@ -53,7 +53,7 @@ The CLI interface MUST work without relying on any network connection.
 base16 TEMPLATES-DIRECTORY SCHEME-FILE ...
 ```
 
-`TEMPLATES-DIRETORY` being a directory containing a `config.yaml`, as well as at
+`TEMPLATES-DIRECTORY` being a directory containing a `config.yaml`, as well as at
 least one `.mustache` template. These are usually named `templates` on all
 base16 template repositories.
 

--- a/builder.md
+++ b/builder.md
@@ -165,7 +165,7 @@ best practices on their respective programming languages.
 Official reference implementations will follow semantic versioning matching
 this spec, in the format: `<base16-version>-builder_revision`.
 
-## 5. Considerations
+## 4. Considerations
 Mustache was chosen as the templating language due to its simplicity and
 widespread adoption across languages. YAML was chosen to describe scheme and
 configuration files for the same reasons.

--- a/builder.md
+++ b/builder.md
@@ -44,6 +44,7 @@ template files it processes:
 - `scheme-name` - obtained from the scheme file
 - `scheme-author` - obtained from the scheme file
 - `scheme-slug` - obtained from the scheme filename, as described above
+- `scheme-kind` - either "light" or "dark", calculated from the `base00` color <!-- TODO: This is a candidate for inclusion, let me know your thoughts -->
 
 - `base00-hex` to `base0F-hex` - obtained from the scheme file e.g "7cafc2"
 - `base00-hex-r` to `base0F-hex-r` - built from the hex value in the scheme file e.g "7c"
@@ -79,13 +80,14 @@ To be fully compliant, a builder CLI interface MUST NOT include any other
 feature, option, argument, or deviance from the expected interface and
 behaviour of the program.
 
+#### 3.1.1 CLI Arguments and options
 <!-- TODO: For convenience, we make a manpage and set of tests available. All
 compliant builders MUST fully conform to these two. -->
 
 The CLI interface MUST work without relying on any network connection.
 
 ```bash
-base16 TEMPLATES-DIRECTORY SCHEME-FILE ...
+base16 <TEMPLATES-DIRECTORY> <SCHEME-FILE> ...
 ```
 
 `TEMPLATES-DIRECTORY` being a directory containing a `config.yaml`, as well as at
@@ -107,6 +109,41 @@ These three options have output that is considered implementation detail, not
 intended to be scripted with. Thus each author SHOULD implement them as they
 see fit.
 
+#### 3.1.2. CLI output and behaviour
+
+**Note**: All text outputted by the CLI binary is considered implementation
+detail, so the author MAY output whatever they prefer (or no message at all).
+If needed, scripts using the builder SHOULD check for return codes (specified
+below) instead of messages.
+
+For all templates defined in the template config file (`config.yaml`, inside
+the specified `TEMPLATES-DIRECTORY`), the builder MUST iterate through all the
+specified schemes and output matching files.
+
+The built filenames MUST be relative to the directory where the command is
+executed, and MUST look like `<output-dir>/base16-<slug><extension>`, where the
+`SLUG` is taken from the scheme filename made lowercase with spaces replaced
+with dashes and both the extension and `output-dir` are taken from
+`config.yaml`.
+
+If the build fails for any reasons, the program MUST exit with code `1` and MAY
+output an error message. This is not exhaustive and new exit codes might be
+added in the future to account for specific errors, so scripters catching
+generic errors SHOULD check for non-zero status.
+
+Otherwise, the program MUST exit with code `0` and an OPTIONAL success message.
+
+#### 3.1.3 CLI example:
+
+```bash
+git clone https://github.com/base16-project/base16-vim.git
+git clone https://github.com/base16-project/base16-schemes.git
+base16 base16-vim/templates base16-schemes/*.yaml
+```
+
+Should create a `colors` (on the current directory) containing `base16-XXX.vim`
+files.
+
 ### 3.2. Library
 
 The other option is exposing a software library other developers may use to
@@ -116,37 +153,15 @@ As above, the library MUST a single feature: building templates.
 
 This exposed library, or any internal code, has no specific required structure.
 
-The author MAY choose how (through a class, single function, etc) they will
-expose these functionalities to the caller, according to their judegment.
+The author MAY choose how (through a class, function that operates on file
+paths, etc) they will expose the builder functionality to the caller, according
+to their judgement.
 
-They SHOULD try to achieve an ergonomical interface and follow the best
-practices on their respective programming languages.
+They SHOULD try to achieve an ergonomical and powerful interface and follow the
+best practices on their respective programming languages.
 
 Official reference implementations will follow semantic versioning matching
 this spec, in the format: `<base16-version>-builder_revision`.
-
-## 4. Output and behaviour
-
-**Note**: All text outputted by the CLI binary is considered implementation
-detail, so the author MAY output whatever they prefer (or no message at all).
-If needed, scripts using the builder SHOULD check for return codes (specified
-below) instead of messages.
-
-For all templates defined in the template config file (`config.yaml`, inside
-the specified template directory), the builder MUST iterate through all the
-defined schemes and output matching files.
-
-The built filename MUST look like `<output-dir>/base16-<slug><extension>`,
-where the slug is taken from the scheme filename made lowercase with spaces
-replaced with dashes and both the extension and output-dir are taken from
-`config.yaml`.
-
-If the build fails for any reasons, the program MUST exit with code `1` and MAY
-output an error message. This is not exhaustive and new exit codes might be
-added in the future to account for specific errors, so scripters catching
-generic errors SHOULD check for non-zero status.
-
-Otherwise, the program MUST exit with code `0` and an OPTIONAL success message.
 
 ## 5. Considerations
 Mustache was chosen as the templating language due to its simplicity and

--- a/builder.md
+++ b/builder.md
@@ -81,11 +81,12 @@ To be fully compliant, a builder CLI interface MUST NOT include any other
 feature, option, argument, or deviance from the expected interface and
 behaviour of the program.
 
-#### 3.1.1 CLI Arguments and options
 <!-- TODO: For convenience, we make a manpage and set of tests available. All
 compliant builders MUST fully conform to these two. -->
 
 The CLI interface MUST work without relying on any network connection.
+
+#### 3.1.1 CLI Arguments and options
 
 ```bash
 base16 <TEMPLATES-DIRECTORY> <SCHEME-FILE> ...

--- a/builder.md
+++ b/builder.md
@@ -1,41 +1,74 @@
-# Builder Guidelines
+# Base16 builder specification
 **Version 0.11.0**
 
 *The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).*
 
-## Introduction
+## 1. Introduction
 
-A base16 builder is, essentially, an application that can build base16
-templates with base16 [schemes](./styling.md).
+"Building" refers to replacing placeholders on base16 _[template
+files](./file.md)_ with colors from base16 _[schemes](./styling.md)_.
 
-A template is a "blueprint" that specifies a file representing how to use the
-16 base16 colors with that specific software/format. For example: a
-[colorscheme template for vim](https://github.com/base16-project/base16-vim).
+A template is a mustache file that acts as a "blueprint": it represents how to
+output the scheme into other file formats, or (more commonly) how to output a
+configuration file to theme a specific software. For example: a [vim
+template](https://github.com/base16-project/base16-vim/blob/main/templates/default.mustache).
 
-A scheme is a color palette that consists of 16 colors (hence the name). For
-example: [the solarized scheme](https://github.com/base16-project/base16-schemes/blob/main/solarized-dark.yaml)
+A scheme is a yaml file that represents a palette of 16 colors: to be replaced
+on the placeholders the template files hold. For example: the [solarized
+scheme](https://github.com/base16-project/base16-schemes/blob/main/solarized-dark.yaml)
 
-Builders are designed for lower-level ("plumbing") usage, specifically for
-scripting and as component to build more complex base16 applications.
+A base16 builder is, essentially, an application that somehow implements the
+_building_ feature specification.
 
-The more complex apps designed for end users ("porcelain") are usually referred
-to as **managers**, and they don't need to follow any standard besides helping
-with base16 theming somehow, in a way that makes sense for their intended
-usecase.
+Builders are categorized into:
 
-Template maintainers SHOULD provide built versions (with all existing scheme)
-so the end user doesn't need to be aware of the builder.
+- _reference tooling_: These follow the spec closely and are
+  designed for unopinionated lower-level ("plumbing") usage, specifically for
+  scripting and as component to build more complex base16 applications. High
+  quality reference builders will usually be adopted by the base16-project
+  organization;
+- _extended tooling_: These are built for end users and are usually tailored
+  for a usecase. This includes GUI apps, ergonomical CLI tools, scheme
+  managers, web apps, and more. These apps are encouraged to use (or create)
+  reference implementations as libraries, but may also implement the builder
+  feature themselves. All of the following `MUST`s can be replaced by `SHOULD`s
+  when writing this kind of tooling.
 
-## Interface
+## 2. Template variables spec
 
-All base16 builders MUST provide a single feature: building a template using 1 or more schemes.
+A builder tool MUST provide the following variables, and no others, to the
+template files it processes:
 
-### CLI
+- `scheme-name` - obtained from the scheme file
+- `scheme-author` - obtained from the scheme file
+- `scheme-slug` - obtained from the scheme filename, as described above
 
-It is REQUIRED that that this functionality is exposed as binary CLI executable
-with the exact interface described below.
+- `base00-hex` to `base0F-hex` - obtained from the scheme file e.g "7cafc2"
+- `base00-hex-r` to `base0F-hex-r` - built from the hex value in the scheme file e.g "7c"
+- `base00-hex-g` to `base0F-hex-g` - built from the hex value in the scheme file e.g "af"
+- `base00-hex-b` to `base0F-hex-b` - built from the hex value in the scheme file e.g "c2"
+- `base00-hex-bgr` to `base0F-hex-bgr` - built from a reversed version of all the hex values e.g "c2af7c"
+
+- `base00-rgb-r` to `base0F-rgb-r` - converted from the hex value in the scheme file e.g "124"
+- `base00-rgb-g` to `base0F-rgb-g` - converted from the hex value in the scheme file e.g "175"
+- `base00-rgb-b` to `base0F-rgb-b` - converted from the hex value in the scheme file e.g "194"
+- `base00-dec-r` to `base0F-dec-r` - converted from the rgb value in the scheme file e.g "0.87..."
+- `base00-dec-g` to `base0F-dec-g` - converted from the rgb value in the scheme file e.g "0.50..."
+- `base00-dec-b` to `base0F-dec-b` - converted from the rgb value in the scheme file e.g "0.21..."
+
+## 3. Interface
+
+All base16 reference builders MUST provide a single feature: building a
+template using 1 or more schemes.
+
+This section is not relevant to extended tooling, which will have its own
+interface fitting their intended usecases. You should jump to section `4`.
+
+It is REQUIRED that this functionality is exposed by one (or both) of the following:
+
+### 3.1. CLI
 
 The binary name SHOULD contain `base16`, but is otherwise left as a choice to
 the author.
@@ -72,69 +105,48 @@ These three options have output that is considered implementation detail, not
 intended to be scripted with. Thus each author SHOULD implement them as they
 see fit.
 
-### Library
+### 3.2. Library
 
-The compliant base16 builder software MAY also expose a software library other
-developers may use to assist developing more complex base16-compatible
-software.
+The other option is exposing a software library other developers may use to
+assist developing more complex base16-compatible tooling.
 
-This exposed library, or any internal code, has no required structure or usage.
+As above, the library MUST a single feature: building templates.
 
-The author MAY choose how they will expose these functionalities to the caller,
-according to their preferences and SHOULD follow best practices on their
-respective programming languages.
+This exposed library, or any internal code, has no specific required structure.
 
-It is RECOMMENDED that builders follow semantic versioning for their library
-interface.
+The author MAY choose how (through a class, single function, etc) they will
+expose these functionalities to the caller, according to their judegment.
 
-The author MAY implement additional features that are exposed through the
-library, as long as it does not affect the CLI functionality compliance.
+They SHOULD try to achieve an ergonomical interface and follow the best
+practices on their respective programming languages.
 
-## Output and behaviour
+Official reference implementations will follow semantic versioning matching
+this spec, in the format: `<base16-version>-builder_revision`.
 
-**Note**: As the CLI is not intended for usual human usage, all outputted text
-messages are considered implementation detail, so the author MAY output
-whatever they prefer (or no message at all). If needed, scripts using the
-builder SHOULD check for return codes (specified below) instead of messages.
+## 4. Output and behaviour
+
+**Note**: All text outputted by the CLI binary is considered implementation
+detail, so the author MAY output whatever they prefer (or no message at all).
+If needed, scripts using the builder SHOULD check for return codes (specified
+below) instead of messages.
 
 For all templates defined in the template config file (`config.yaml`, inside
 the specified template directory), the builder MUST iterate through all the
 defined schemes and output matching files.
 
-The built filename should look like [output-dir]/base16-[slug][extension],
+The built filename MUST look like `<output-dir>/base16-<slug><extension>`,
 where the slug is taken from the scheme filename made lowercase with spaces
 replaced with dashes and both the extension and output-dir are taken from
 `config.yaml`.
 
-The builder MUST check for the (unusual) case where schemes share the same
-slug, in this case the program MUST exit with code `1` and MAY output an error
-message.
+If the build fails for any reasons, the program MUST exit with code `1` and MAY
+output an error message. This is not exhaustive and new exit codes might be
+added in the future to account for specific errors, so scripters catching
+generic errors SHOULD check for non-zero status.
 
-If the build fails for whatever other reasons, the program MUST exit with code
-`2` and MAY output an error message.
+Otherwise, the program MUST exit with code `0` and an OPTIONAL success message.
 
-## Template Variables
-A builder MUST provide the following, and no others, variables to the template
-files it processes:
-
-- `scheme-name` - obtained from the scheme file
-- `scheme-author` - obtained from the scheme file
-- `scheme-slug` - obtained from the scheme filename, as described above
-
-- `base00-hex` to `base0F-hex` - obtained from the scheme file e.g "7cafc2"
-- `base00-hex-r` to `base0F-hex-r` - built from the hex value in the scheme file e.g "7c"
-- `base00-hex-g` to `base0F-hex-g` - built from the hex value in the scheme file e.g "af"
-- `base00-hex-b` to `base0F-hex-b` - built from the hex value in the scheme file e.g "c2"
-- `base00-hex-bgr` to `base0F-hex-bgr` - built from a reversed version of all the hex values e.g "c2af7c"
-
-- `base00-rgb-r` to `base0F-rgb-r` - converted from the hex value in the scheme file e.g "124"
-- `base00-rgb-g` to `base0F-rgb-g` - converted from the hex value in the scheme file e.g "175"
-- `base00-rgb-b` to `base0F-rgb-b` - converted from the hex value in the scheme file e.g "194"
-- `base00-dec-r` to `base0F-dec-r` - converted from the rgb value in the scheme file e.g "0.87..."
-- `base00-dec-g` to `base0F-dec-g` - converted from the rgb value in the scheme file e.g "0.50..."
-- `base00-dec-b` to `base0F-dec-b` - converted from the rgb value in the scheme file e.g "0.21..."
-
-## Considerations
+## 5. Considerations
 Mustache was chosen as the templating language due to its simplicity and
 widespread adoption across languages. YAML was chosen to describe scheme and
 configuration files for the same reasons.

--- a/builder.md
+++ b/builder.md
@@ -63,8 +63,10 @@ template files it processes:
 All base16 reference builders MUST provide a single feature: building a
 template using 1 or more schemes.
 
-This section is not relevant to extended tooling, which will have its own
-interface fitting their intended usecases. You should jump to section `4`.
+This section (`3`) is not relevant to extended tooling, which will have its own
+interface fitting their intended usecases, altough they MAY expose the
+reference CLI interface (through a `build` subcommand, for example) and/or a
+library, if desired.
 
 It is REQUIRED that this functionality is exposed by one (or both) of the following:
 

--- a/builder.md
+++ b/builder.md
@@ -138,5 +138,5 @@ changes.
 
 The revised builder functionality specification introduced in v0.11 did not
 introduce any changes to schemes or templates, so no changes to these are
-needed Older builders will continue to work, but authors are encouraged to
+needed. Older builders will continue to work, but authors are encouraged to
 implement the new, simpler and more consistent, specification.

--- a/builder.md
+++ b/builder.md
@@ -18,8 +18,12 @@ A scheme is a color palette that consists of 16 colors (hence the name). For
 example: [the solarized scheme](https://github.com/base16-project/base16-schemes/blob/main/solarized-dark.yaml)
 
 Builders are designed for lower-level ("plumbing") usage, specifically for
-scripting and as component to build more complex base16 applications, designed
-for end users ("porcelain").
+scripting and as component to build more complex base16 applications.
+
+The more complex apps designed for end users ("porcelain") are usually referred
+to as **managers**, and they don't need to follow any standard besides helping
+with base16 theming somehow, in a way that makes sense for their intended
+usecase.
 
 Template maintainers SHOULD provide built versions (with all existing scheme)
 so the end user doesn't need to be aware of the builder.

--- a/builder.md
+++ b/builder.md
@@ -107,8 +107,8 @@ If the build fails for whatever other reasons, the program MUST exit with code
 `2` and MAY output an error message.
 
 ## Template Variables
-A builder MUST provide the following variables to the template files it
-processes:
+A builder MUST provide the following, and no others, variables to the template
+files it processes:
 
 - `scheme-name` - obtained from the scheme file
 - `scheme-author` - obtained from the scheme file

--- a/builder.md
+++ b/builder.md
@@ -33,6 +33,9 @@ All base16 builders MUST provide a single feature: building a template using 1 o
 It is REQUIRED that that this functionality is exposed as binary CLI executable
 with the exact interface described below.
 
+The binary name SHOULD contain `base16`, but is otherwise left as a choice to
+the author.
+
 To be fully compliant, a builder CLI interface MUST NOT include any other
 feature, option, argument, or deviance from the expected interface and
 behaviour of the program.

--- a/builder.md
+++ b/builder.md
@@ -61,9 +61,16 @@ base16 template repositories.
 is the [base16-schemes](https://github.com/base16-project/base16-schemes)
 repository.
 
-The program MAY offer a single `--debug | -d` option for increasing log
-verbosity. These are considered implementation detail and each author SHOULD
-implement them as they see fit.
+The program MAY also offer the following options:
+
+- `--debug | -d` option(s) for increasing log verbosity;
+- `--version | -v` option to output its current running version;
+- `--help | -h` option to output usage information directly or by opening the
+  manpage.
+
+These three options have output that is considered implementation detail, not
+intended to be scripted with. Thus each author SHOULD implement them as they
+see fit.
 
 ### Library
 

--- a/builder.md
+++ b/builder.md
@@ -151,7 +151,7 @@ files.
 The other option is exposing a software library other developers may use to
 assist developing more complex base16-compatible tooling.
 
-As above, the library MUST a single feature: building templates.
+As above, the library MUST implement single feature: building templates.
 
 This exposed library, or any internal code, has no specific required structure.
 


### PR DESCRIPTION
Hey!

Based on my [comment on #3](https://github.com/base16-project/base16/issues/3#issuecomment-1162926162), I've decided to go ahead and make a draft of what I had in mind, in the form of a reworked builder specification.

I think I'm done writing (there may be some typos around or wording fixes), so I'm ready for review and comments!

Please let me know what you think :)

## Rationale

- Builders have interfaces (arguments, etc) that are completely different between one another, yet mostly do the same thing. This makes any CI using them coupled to the specific builder, not the formal specification.
- Every single software using base16 somehow has their own base16 implementation, we should try and provide libraries for this. Builders could act as both a CLI and software library for their respective languages, with minimal additional work.
- The current specification is very loose and uses a lot of "shoulds", so it's completely left to what the author wants to do, making standardization more difficult.
- There is a blurred line between a software that "builds" and "manages" base16 templates/schemes.
  - The current specification says that builders must fetch stuff. This is awkward to use when scripting (you have to manipulate data dirs repeately)
  - For the software more geared towards users, the "update" workflow is also very awkward and makes it really hard for users to manage their overrides. When we had a template index, it was really easy to delete custom templates.
- I propose we make the definition 100% clear. Managers are for end users, contain opinionated workflows, and can do pretty much whatever the author thinks that makes sense to their usage. While builders are highly scoped, consistent, and very, very easy to script with.

## Expected results
- Builders that are dead-simple to use with CI
- The manager definition is made clear
- Software that uses base16 will be easier to implement, be more correct and more interoperable (we can, for example, build a library to generate actual base16 schemes from images).
- Make the builder document as unambiguous as possible, while being as easy as possible to read
- This will not introduce any incompatibility between schemes, templates, and existing builders. The only thing changing is the recommended way of writing an official builder.

## Changes

- I'm proposing we make builders only build templates. It is now required that builders (at least the features exposed via CLI) only offer build functionality, not management or anything else. 
- The idea is that, as they are a plumbing tool, they should follow a strict interface and behaviour standard, making them fully interoperable and avoiding protocol extension (improvements should instead be contributed back here). It's not a law binding, of course, but I think being fully compliant should be a requirement for endorsement.
- There is also an optional interface the builder may implement, in the form of a software library for their respective language/platform. This should help everyone that makes base16-compatible software!
- As the builders no longer are designed to fetch repositories, the template directory (containing `config.yaml` and `.mustache`'s) and scheme list are required arguments.
- When we have a slug conflict, which is very unusual I'd say, I've specified that the program must instead exit with an error. This should be easier to script with, as well as very easy to implement, as all scheme files (thus their slugs) are specified as an argument.
- I've made `hex` and `hex-bgr` mandatory, to encourage 100% compatibility between builders. 
- I've adopted the [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) keyword description. The previous specification contained a lot of "shoulds" where it should have been "must".
- The specification is a lot more strict now. It specifies exactly what arguments the CLI has, and its full behaviour.


## Questions
- Should we adopt @belak's `slug-underscored`? I believe it makes sense as to avoid builders not having it.
- Is my idea of erroring out when the file exists okay? Or is there a specific reason for the current behaviour? Warnings are quite hard to script with
- Does it make sense (added a todo for it) to write an official manpage and test suite for the builders? I like it but would like feedback on that before commiting to it.