### PR TITLE
Various README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 0.10.0 (Mar 20, 2021)
+
+- Simplify repo structure and builder responsibilities
+- Clarify that using a hash as a part of the color is allowed
+
+## 0.9.1 (Jun 15, 2019)
+
+- Make baseXX-hex-bgr variables available to templates
+- Warn when a template file has been overwritten
+
+## 0.9.0 (Jul 6, 2017)
+
+- Add decimal color variables
+
+## 0.8.1 (Dec 29, 2016)
+
+- Clarify theme filename generation
+- Various clarifications
+
+## 0.8.0 (Aug 27, 2016)
+
+- Drop support for HSL variables

--- a/README.md
+++ b/README.md
@@ -210,56 +210,15 @@ Normally end-users should not need to use builders, as they're primarily meant
 for maintainers - both scheme and template maintainers. These are tools used to
 build templates with all the currently submitted schemes.
 
-### Official Builder Repositories
+Spec changes will not be merged until there is consensus among maintainers and
+at least one builder with a pull request ready for implementing that spec
+version.
 
-Similar to our split between official and unofficial templates, we also have a
-similar split for builders. Spec changes will not be merged until there is
-consensus among maintainers and at least one builder with a pull request ready
-for implementing that spec version.
+See the [CHANGELOG](/CHANGELOG.md) for more information about changes in the
+spec.
 
 * [Base 16 Builder Go](https://github.com/base16-project/base16-builder-go) maintained by [belak](https://github.com/belak) - currently supports 0.10.0
 * [Base16 Builder Node](https://github.com/base16-project/base16-builder-node) maintained by [JoshGoebel](https://github.com/JoshGoebel) - currently supports 0.10.0
-
-### Unofficial Builder Repositories
-
-**Repository naming scheme: base16-builder-[language]** (with dashes as separators). The separate headings are the latest versions of the spec supported by each builder.
-
-### Changelog
-
-#### 0.10.0 (Mar 20, 2021)
-
-- Simplify repo structure and builder responsibilities
-- Clarify that using a hash as a part of the color is allowed
-
-#### 0.9.1 (Jun 15, 2019)
-
-- Make baseXX-hex-bgr variables available to templates
-- Warn when a template file has been overwritten
-
-* [Base 16 Builder Ansible](https://github.com/mnussbaum/base16-builder-ansible) maintained by [mnussbaum](https://github.com/mnussbaum)
-* [Base 16 Builder PHP](https://github.com/chriskempson/base16-builder-php) maintained by [chriskempson](https://github.com/chriskempson)
-* [Base 16 Builder Python](https://github.com/InspectorMustache/base16-builder-python) maintained by [InspectorMustache](https://github.com/InspectorMustache)
-* [Base 16 Builder Rust](https://github.com/ilpianista/base16-builder-rust) maintained by [ilpianista](https://github.com/ilpianista)
-
-#### 0.9.0 (Jul 6, 2017)
-
-- Add decimal color variables
-
-* [Base 16 Builder Clojure](https://github.com/nhurden/base16-builder-clojure) maintained by [nhurden](https://github.com/nhurden)
-* [Base 16 Builder Elixir](https://github.com/obahareth/base16-builder-elixir) maintained by [obahareth](https://github.com/obahareth)
-* [Base 16 Builder Ruby](https://github.com/obahareth/base16-builder-ruby) maintained by [obahareth](https://github.com/obahareth)
-* [Base 16 Builder Typescript](https://github.com/golf1052/base16-builder-typescript) maintained by [golf1052](https://github.com/golf1052)
-
-#### 0.8.1 (Dec 29, 2016)
-
-- Clarify theme filename generation
-- Various clarifications
-
-* [Base 16 Builder Perl](https://github.com/loomer/base16-builder-perl) maintained by [loomer](https://github.com/loomer)
-
-#### 0.8.0 (Aug 27, 2016)
-
-- Drop support for HSL variables
 
 ## Scheme and Template Author Resources
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ If you've written a tool for base16 feel free to add it to the list below:
 
 * [base16-mutt](https://github.com/josephholsten/base16-mutt) - a config file for mutt which uses base16 colors from the terminal
 
+## Project Chat
+
+Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by the #base16 channel on [Libera Chat](https://libera.chat/) to talk about it.
+
 ## Credits
 
 Thanks to [Chris Kempson](https://github.com/chriskempson) for the original concept and implementation.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Normally end-users should not need to use builders, as they're primarily meant
 for maintainers - both scheme and template maintainers. These are tools used to
 build templates with all the currently submitted schemes.
 
-Spec changes will not be merged until there is consensus among maintainers and
+Spec changes will not be released until there is consensus among maintainers and
 at least one builder with a pull request ready for implementing that spec
 version.
 


### PR DESCRIPTION
This encapsulates a number of smaller README changes.

* Move changelog to CHANGELOG.md
* Add info on the Libera Chat channel
* Drops unofficial builders from the README for now  

Closes #32, Closes #30 