### PR TITLE
Additional chat links

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If you've written a tool for base16 feel free to add it to the list below:
 
 ## Project Chat
 
-Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by the [#base16 channel](https://web.libera.chat/#base16) on [Libera Chat](https://libera.chat/) to talk about it.
+Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by the [#base16 channel](https://web.libera.chat/#base16) on [Libera Chat](https://libera.chat/) or the [bridged Matrix channel](https://matrix.to/#/#base16:libera.chat) to talk about it.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If you've written a tool for base16 feel free to add it to the list below:
 
 ## Project Chat
 
-Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by the #base16 channel on [Libera Chat](https://libera.chat/) to talk about it.
+Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by the [#base16 channel](https://web.libera.chat/#base16) on [Libera Chat](https://libera.chat/) to talk about it.
 
 ## Credits
 


### PR DESCRIPTION
Add an `irc://` link for the channel as well as a matrix.to Link for the bridged Matrix room.